### PR TITLE
Broken link inside editor and checked compatibility with 6.2

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@master
+      uses: 10up/action-wordpress-plugin-asset-update@stable
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **Tags:** liftlms, course, page-buider, beaver builder, elementor, visual composer  
 **Requires at least:** 4.4  
 **Requires PHP:** 5.3  
-**Tested up to:** 6.1  
-**Stable tag:** 1.0.5  
+**Tested up to:** 6.2  
+**Stable tag:** 1.0.6  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -41,6 +41,9 @@ This plugin currently works best with the <a href="https://wpastra.com/?utm_sour
 5. For enrolled students, the normal course page appears.
 
 ## Changelog ##
+
+### 1.0.6  ###
+- Fix: Updated broken link found inside editor.
 
 ### 1.0.5  ###
 - Improvement: Added compatibility to WordPress 6.1

--- a/admin/class-ctlearndash-admin.php
+++ b/admin/class-ctlearndash-admin.php
@@ -101,7 +101,7 @@ if ( ! class_exists( 'CTLearnDash_Admin' ) ) {
 			echo sprintf(
 				/* translators: 1: anchor start, 2: anchor close */
 				esc_html__( '%1$sSee list of all LearnDash shortcodes%2$s that you can add in the custom template.', 'custom-template-learndash' ),
-				'<a href="https://learndash.com/docs/shortcodes/" target="_blank" rel="noopner" >',
+				'<a href="https://www.learndash.com/support/docs/core/shortcodes-blocks/" target="_blank" rel="noopner" >',
 				'</a>'
 			);
 

--- a/custom-template-learndash.php
+++ b/custom-template-learndash.php
@@ -7,7 +7,7 @@
  * Author URI:      https://pratikchaskar.com/
  * Text Domain:     custom-template-learndash
  * Domain Path:     /languages
- * Version:         1.0.5
+ * Version:         1.0.6
  *
  * @package         Custom Template for LearnDash
  */
@@ -25,7 +25,7 @@ function ctlearndash_activation() {
 	add_option( 'ctlearndash_activation', 'is-activated' );
 }
 
-define( 'CTLEARNDASH_VER', '1.0.5' );
+define( 'CTLEARNDASH_VER', '1.0.6' );
 define( 'CTLEARNDASH_FILE', __FILE__ );
 define( 'CTLEARNDASH_DIR', plugin_dir_path( __FILE__ ) );
 define( 'CTLEARNDASH_URL', plugins_url( '/', __FILE__ ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-template-learndash",
-  "version": "1.0.2",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-template-learndash",
-  "version": "1.0.2",
+  "version": "1.0.6",
   "main": "Gruntfile.js",
   "author": "YOUR NAME HERE",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: pratikchaskar, wpcrafter
 Tags: liftlms, course, page-buider, beaver builder, elementor, visual composer
 Requires at least: 4.4
 Requires PHP: 5.3
-Tested up to: 6.1
-Stable tag: 1.0.5
+Tested up to: 6.2
+Stable tag: 1.0.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -41,6 +41,9 @@ This plugin currently works best with the <a href="https://wpastra.com/?utm_sour
 5. For enrolled students, the normal course page appears.
 
 == Changelog ==
+
+= 1.0.6  =
+- Fix: Updated broken link found inside editor.
 
 = 1.0.5  =
 - Improvement: Added compatibility to WordPress 6.1


### PR DESCRIPTION
Summary
- Provided WordPress 6.2 Compatibility.
- Fix: Updated broken link found inside editor.

Testing 
- Checked with Astra + LearnDash
- Checked with Astra + Astra addon + LearnDash
- Checked in customizer 
- Check if custom template gets made gets applied for courses 
- Checked if broken link for shortcode works well.