### PR TITLE
WordPress 7.1 Compatibility

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -7,6 +7,7 @@ jobs:
   master:
     name: Push to master
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -15,3 +15,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        IGNORE_OTHER_FILES: true

--- a/.github/workflows/push-to-deploy.yml
+++ b/.github/workflows/push-to-deploy.yml
@@ -7,8 +7,18 @@ jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+    - name: Verify release tag is reachable from master
+      run: |
+        git fetch --no-tags --depth=50 origin master:refs/remotes/origin/master
+        if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/master; then
+          echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from master. Refusing to deploy."
+          exit 1
+        fi
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@master
       env:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** liftlms, course, page-buider, beaver builder, elementor, visual composer  
 **Requires at least:** 4.4  
 **Requires PHP:** 5.3  
-**Tested up to:** 6.9  
+**Tested up to:** 7.0  
 **Stable tag:** 1.0.7  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** liftlms, course, page-buider, beaver builder, elementor, visual composer  
 **Requires at least:** 4.4  
 **Requires PHP:** 5.3  
-**Tested up to:** 7.0  
+**Tested up to:** 7.1  
 **Stable tag:** 1.0.7  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,11 @@
 {
   "name": "pratikchaskar/custom-template-learndash",
   "description": "Custom Template Learndash in Astra Theme",
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  },
   "require-dev": {
       "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
       "wp-coding-standards/wpcs": "dev-master",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Tags: liftlms, course, page-buider, beaver builder, elementor, visual composer
 Requires at least: 4.4
 Requires PHP: 5.3
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Tags: liftlms, course, page-buider, beaver builder, elementor, visual composer
 Requires at least: 4.4
 Requires PHP: 5.3
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## WordPress 7.1 Compatibility
- Tested with WordPress 7.1 and it's working fine (bumped `Tested up to` in `README.md` and `readme.txt`).

## Deploy workflow hardening (ports [astra-sites#886](https://github.com/brainstormforce/astra-sites/pull/886))
- Added `environment: production` to the deploy jobs so org-level `SVN_*` secrets are only reachable from workflows running on `master` + tags (via a scoped `production` GitHub Environment restricted to those refs).
- Added a guard in `push-to-deploy.yml` that refuses to deploy a tag not reachable from `master`.

## CI fix
- Defined `config.allow-plugins` in `composer.json` for `dealerdirect/phpcodesniffer-composer-installer` — the phpcs workflow was failing on `composer install` under Composer 2.x's allow-plugins gate.

## Release tracking
Closes brainstormforce/astra#8031 (WordPress 7.1 compatibility release epic)

